### PR TITLE
Added missing NGX_PARSE_LARGE_TIME

### DIFF
--- a/ngx_http_uploadprogress_module.c
+++ b/ngx_http_uploadprogress_module.c
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2007 Brice Figureau
  * shm_zone and rbtree code Copyright (c) 2002-2007 Igor Sysoev
@@ -9,6 +8,11 @@
 #include <ngx_http.h>
 
 #define TIMER_FREQUENCY 15 * 1000
+
+/* NGX_PARSE_LARGE_TIME was removed in  1.1.15 */
+#ifndef NGX_PARSE_LARGE_TIME
+    #define NGX_PARSE_LARGE_TIME -2
+#endif /* NGX_PARSE_LARGE_TIME */
 
 typedef enum {
     uploadprogress_state_starting = 0,


### PR DESCRIPTION
Added missing constant. This isn't a _proper_ fix but rather a workaround. With the upcoming **stable** status of the 1.1.x branch this needs further work.
