### PR TITLE
Properly track progress of smaller file uploads

### DIFF
--- a/ngx_http_uploadprogress_module.c
+++ b/ngx_http_uploadprogress_module.c
@@ -833,6 +833,15 @@ ngx_http_uploadprogress_handler(ngx_http_request_t * r)
     up->length = 0;
     up->timeout = 0;
 
+    // Properly handles small files where no read events happen after the
+    // request is first handled
+    if (r->headers_in.content_length_n) {
+        up->length = r->headers_in.content_length_n;
+        if (r->request_body) {
+            up->rest = r->request_body->rest;
+        }
+    }
+
     up->next = ctx->list_head.next;
     up->next->prev = up;
     up->prev = &ctx->list_head;


### PR DESCRIPTION
When uploading smaller files (I noticed it especially apparent with Firefox connected to a local server), the progress module will never have the `ngx_http_uploadprogress_event_handler` function called, which means the length and remaining values are set.

Because of this, calls to the progress endpoint will return `starting` even though the file has been fully uploaded and the request is now being processed by the handler. This is more obvious when the handler does some sort of processing such as resizing images or uploading files to another storage service.

This patch will check the headers and amount of the request body that has been read when first initializing the upload in `ngx_http_uploadprogress_handler`, which means really small files will be properly reported.
