### PR TITLE
 config: Fix ngx_module_type

### DIFF
--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 ngx_addon_name=ngx_http_uploadprogress_module
 if test -n "$ngx_module_link"; then
-    ngx_module_type=FILTER
+    ngx_module_type=HTTP_FILTER
     ngx_module_name=ngx_http_uploadprogress_module
     ngx_module_srcs="$ngx_addon_dir/ngx_http_uploadprogress_module.c"
 


### PR DESCRIPTION
Since commit 37182ce2f3b6 the module was always build as dynamic module.
Probably because following a bad skeleton [1].

With this change we will only build a dynamic module when requested. Otherwise
we will fall back to static build.

Link: https://trac.nginx.org/nginx/ticket/1115
Gentoo-Bug: https://bugs.gentoo.org/593450
Fixes: https://github.com/masterzen/nginx-upload-progress-module/issues/50